### PR TITLE
Fix a bug in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $('.toc-src').tocjs();
 ## Options
 
 ```
-$('.toc-src').toc({
+$('.toc-src').tocjs({
   excludes: 'toc-exclude',
   headingNumber: true,
   headings: 'h2, h3',


### PR DESCRIPTION
It seems that you have used a invalid function called `toc`. I  tried for several times and found out that it should be `tocjs`.